### PR TITLE
Add link preview for notes and privacy setting to enable/disable it

### DIFF
--- a/apps/native/src-tauri/src/utils.rs
+++ b/apps/native/src-tauri/src/utils.rs
@@ -24,6 +24,7 @@ pub struct Settings {
     pub export_format: String,
     pub sort_type: String,
     pub auto_check_updates: bool,
+    pub link_preview_enabled: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -52,6 +53,7 @@ impl Default for Settings {
             export_format: "json".to_string(),
             sort_type: "newest".to_string(),
             auto_check_updates: false,
+            link_preview_enabled: false,
         }
     }
 }

--- a/packages/ui/src/components/note/LinkPreview.tsx
+++ b/packages/ui/src/components/note/LinkPreview.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from "react";
+import { Link2 } from "lucide-react";
+
+interface LinkPreviewProps {
+  url: string;
+}
+
+const getDomain = (url: string) => {
+  const parsedUrl = new URL(url);
+  return parsedUrl.hostname;
+};
+
+interface PreviewData {
+  title: string;
+  description: string;
+  image: string;
+  url: string;
+}
+
+export const LinkPreview: React.FC<LinkPreviewProps> = ({ url }) => {
+  const [data, setData] = useState<PreviewData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!url) return;
+    setLoading(true);
+    setError(null);
+    fetch(`https://api.microlink.io/?url=${encodeURIComponent(url)}`)
+      .then((res) => res.json())
+      .then((res) => {
+        if (res.status === 'success') {
+          setData({
+            title: res.data.title,
+            description: res.data.description,
+            image: res.data.image?.url || '',
+            url: res.data.url,
+          });
+        } else {
+          setError('Preview not available');
+        }
+      })
+      .catch(() => setError('Preview not available'))
+      .finally(() => setLoading(false));
+  }, [url]);
+
+  if (loading) return <div className="text-xs text-muted-foreground mt-2">Loading preview...</div>;
+  if (error || !data) return null;
+
+  return (
+    <a
+      href={data.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="block border rounded-xl p-0 bg-background/60 hover:bg-accent/30 transition-colors duration-200 shadow-sm overflow-hidden"
+      style={{ textDecoration: 'none' }}
+    >
+      <div className="flex flex-row items-stretch">
+        {data.image && (
+          <div className="flex-shrink-0 w-24 h-24 bg-muted overflow-hidden flex items-center justify-center">
+            <img
+              src={data.image}
+              alt={data.title}
+              className="object-cover w-full h-full center"
+              style={{ minWidth: 64, minHeight: 64 }}
+            />
+          </div>
+        )}
+        <div className="flex flex-col justify-between flex-1 min-w-0 p-3">
+          <div>
+            <div className="text-base text-foreground truncate">
+              {data.title}
+            </div>
+            <div className="text-sm text-muted-foreground truncate mt-1">
+              {data.description}
+            </div>
+          </div>
+          <div className="flex items-center gap-1 text-xs text-blue-500">
+            <Link2 className="w-4 h-4 opacity-70 mr-1" />
+            <span className="truncate">{getDomain(data.url)}</span>
+          </div>
+        </div>
+      </div>
+    </a>
+  );
+};

--- a/packages/ui/src/components/note/NoteEntryItem.tsx
+++ b/packages/ui/src/components/note/NoteEntryItem.tsx
@@ -19,7 +19,9 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneDark, oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { NoteEntry } from "@repo/ui/lib/database";
 import { highlightText } from "@repo/ui/utils/textUtils";
+import { useSettings } from "@repo/ui/hooks/useSettings";
 import { useTheme } from "@repo/ui/providers/theme-provider";
+import { LinkPreview } from "@repo/ui/components/note/LinkPreview";
 
 interface NoteEntryItemProps {
   entry: NoteEntry;
@@ -46,6 +48,7 @@ export function NoteEntryItem({
 }: NoteEntryItemProps) {
   const isEditing = editingEntry?.id === entry.id;
   const { appliedTheme } = useTheme();
+  const { linkPreviewEnabled } = useSettings();
 
   return (
     <div className="flex flex-col items-end w-full mb-5">
@@ -95,6 +98,14 @@ export function NoteEntryItem({
                 </p>
               ) : (
                 <div className="prose prose-neutral dark:prose-invert prose-pre:bg-transparent prose-pre:m-0 prose-pre:p-0 max-w-none text-[15px] md:text-sm leading-relaxed">
+                  {linkPreviewEnabled && (() => {
+                    const urlRegex = /(https?:\/\/[\w\-._~:/?#[\]@!$&'()*+,;=%]+)/gi;
+                    const match = entry.text.match(urlRegex);
+                    if (match && match[0]) {
+                      return <LinkPreview url={match[0]} />;
+                    }
+                    return null;
+                  })()}
                   <ReactMarkdown
                     remarkPlugins={[remarkGfm, remarkBreaks, remarkToc]}
                     rehypePlugins={[

--- a/packages/ui/src/hooks/useSettings.ts
+++ b/packages/ui/src/hooks/useSettings.ts
@@ -26,7 +26,9 @@ export function useSettings() {
   const [isBackgroundExpanded, setIsBackgroundExpanded] = useState(false);
   const [isExportExpanded, setIsExportExpanded] = useState(false);
   const [isAboutExpanded, setIsAboutExpanded] = useState(false);
+  const [isPrivacyExpanded, setIsPrivacyExpanded] = useState(false);
   const [autoCheckUpdates, setAutoCheckUpdatesState] = useState(false);
+  const [linkPreviewEnabled, setLinkPreviewEnabledState] = useState(false);
 
   const [selectedExportFormat, setSelectedExportFormat] = useState<ExportFormat>("json");
   const [sortType, setSortTypeState] = useState<SortType>("newest");
@@ -46,7 +48,8 @@ export function useSettings() {
     },
     export_format: "json",
     sort_type: "newest",
-    auto_check_updates: false
+    auto_check_updates: false,
+    link_preview_enabled: false
   };
 
   const resetSettings = async () => {
@@ -69,6 +72,9 @@ export function useSettings() {
         }
         if (settings.auto_check_updates) {
           setAutoCheckUpdatesState(settings.auto_check_updates);
+        }
+        if (settings.link_preview_enabled) {
+          setLinkPreviewEnabledState(settings.link_preview_enabled);
         }
         setLoaded(true);
       } catch (e) {
@@ -173,6 +179,21 @@ export function useSettings() {
     }
   };
 
+  const setLinkPreviewEnabled = (enabled: boolean) => {
+    setLinkPreviewEnabledState(enabled);
+    (async () => {
+      try {
+        const settings = await invoke<any>('read_settings');
+        await invoke('write_settings', {
+          settings: {
+            ...settings,
+            link_preview_enabled: enabled,
+          }
+        });
+      } catch (e) {}
+    })();
+  };
+
   const setAutoCheckUpdates = (checked: boolean) => {
     setAutoCheckUpdatesState(checked);
     (async () => {
@@ -234,6 +255,7 @@ export function useSettings() {
     isBackgroundExpanded, setIsBackgroundExpanded,
     isExportExpanded, setIsExportExpanded,
     isAboutExpanded, setIsAboutExpanded,
+    isPrivacyExpanded, setIsPrivacyExpanded,
     autoCheckUpdates, setAutoCheckUpdates,
     selectedExportFormat, setSelectedExportFormat: setSelectedExportFormatAndPersist,
     currentExportFormatDisplay,
@@ -244,6 +266,7 @@ export function useSettings() {
     handleKeyDown,
     handleExportNotes,
     exportFormats,
-    handleCheckForUpdates
+    handleCheckForUpdates,
+    linkPreviewEnabled, setLinkPreviewEnabled,
   };
 } 

--- a/packages/ui/src/views/Settings.tsx
+++ b/packages/ui/src/views/Settings.tsx
@@ -80,6 +80,7 @@ export function Settings({ onClose, SIDEBAR_HEADER_HEIGHT }: SettingsProps) {
     isAppearanceExpanded, setIsAppearanceExpanded,
     isBackgroundExpanded, setIsBackgroundExpanded,
     isExportExpanded, setIsExportExpanded,
+    isPrivacyExpanded, setIsPrivacyExpanded,
     isAboutExpanded, setIsAboutExpanded,
     selectedExportFormat, setSelectedExportFormat,
     currentExportFormatDisplay,
@@ -89,7 +90,8 @@ export function Settings({ onClose, SIDEBAR_HEADER_HEIGHT }: SettingsProps) {
     handleExportNotes,
     exportFormats,
     autoCheckUpdates, setAutoCheckUpdates,
-    handleCheckForUpdates
+    handleCheckForUpdates,
+    linkPreviewEnabled, setLinkPreviewEnabled,
   } = useSettings();
 
   const [checkingUpdate, setCheckingUpdate] = useState(false);
@@ -474,6 +476,42 @@ export function Settings({ onClose, SIDEBAR_HEADER_HEIGHT }: SettingsProps) {
                 <Download className="mr-2 h-4 w-4" />
                 Export All Notes as {currentExportFormatDisplay.label}
               </Button>
+            </CardContent>
+          )}
+        </Card>
+
+        <Card>
+          <CardHeader
+            className="flex items-center justify-between cursor-pointer"
+            onClick={() => setIsPrivacyExpanded(!isPrivacyExpanded)}
+            onKeyDown={(e) => handleKeyDown(e, () => setIsPrivacyExpanded(!isPrivacyExpanded))}
+            role="button"
+            aria-expanded={isPrivacyExpanded}
+            aria-controls="privacy-content"
+            tabIndex={0}
+          >
+            <div>
+              <CardTitle className="text-base">Privacy & Security</CardTitle>
+              <CardDescription className="text-sm">Control privacy and security related features.</CardDescription>
+            </div>
+            {isPrivacyExpanded ? (
+              <ChevronDown className="h-5 w-5 text-muted-foreground shrink-0" />
+            ) : (
+              <ChevronRight className="h-5 w-5 text-muted-foreground shrink-0" />
+            )}
+          </CardHeader>
+          {isPrivacyExpanded && (
+            <CardContent id="privacy-content" className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label className="text-sm font-medium">Enable link previews</Label>
+                  <p className="text-xs text-muted-foreground">Show website previews for links in your notes.</p>
+                </div>
+                <Switch
+                  checked={linkPreviewEnabled}
+                  onCheckedChange={setLinkPreviewEnabled}
+                />
+              </div>
             </CardContent>
           )}
         </Card>


### PR DESCRIPTION
- Detects URLs in note content and displays a website preview (title, description, image, domain) below the note using the microlink.io API.
- Adds an expandable Privacy & Security card to the settings page with a switch to enable or disable link previews for notes.
- The link preview feature is user-controllable and defaults to disabled (off).

![feat](https://github.com/user-attachments/assets/649041ad-2f4f-4106-8c20-c85acdcab40b)
